### PR TITLE
CHIRP: Fix RadioSettingGroup bug and align CPO Mode with firmware menu

### DIFF
--- a/chirp/uvk5_NR7Y.py
+++ b/chirp/uvk5_NR7Y.py
@@ -27,23 +27,26 @@ CW_MACRO_SIG = 0x80
 # CW settings EEPROM addresses
 CW_SETTINGS_ADDR = 0x0F20  # 3 bytes: freq/vol, mode/wpm, key_input
 
-# Key input mode display strings
+# Key input mode display strings (beta3: 10 modes including CEC cable)
 CW_KEY_INPUT_MODES = [
-    "PTT HandKey",
-    "PTT+Port HandKey",
-    "PTT dah, Side1 dit",
-    "PTT dit, Side1 dah",
-    "PTT+Tip dah, Ring dit",
-    "PTT+Tip dit, Ring dah",
-    "Both dah, Both dit",
-    "Both dit, Both dah"
+    "PTT HandKey",                    # 0: 0x08
+    "PTT+Port HandKey",               # 1: 0x18
+    "PTT dah, Side1 dit",             # 2: 0x04
+    "PTT dit, Side1 dah",             # 3: 0x05
+    "PTT+Tip dah, Ring dit",          # 4: 0x12
+    "PTT+Tip dit, Ring dah",          # 5: 0x13
+    "Both dah, Both dit",             # 6: 0x16
+    "Both dit, Both dah",             # 7: 0x17
+    "CEC (PTT dah, Tip dit)",         # 8: 0x20 - NEW beta3
+    "CEC (PTT dit, Tip dah)"          # 9: 0x21 - NEW beta3
 ]
 
-# Map menu selection to bit-mapped values (from firmware)
-CW_KEY_INPUT_BITMAP = [0x08, 0x18, 0x04, 0x05, 0x12, 0x13, 0x16, 0x17]
+# Map menu index to bit-mapped values (beta3: menu index stored, not bitmap)
+# Beta3 stores the menu index (0-9) directly, then converts to bitmap internally
+CW_KEY_INPUT_BITMAP = [0x08, 0x18, 0x04, 0x05, 0x12, 0x13, 0x16, 0x17, 0x20, 0x21]
 
 # Complete programmable key actions list from firmware (settings.h:105-127)
-# This extends the base driver's KEYACTIONS_LIST with NR7Y firmware additions
+# Beta3 extends with repeat actions - synced with firmware beta3
 KEYACTIONS_LIST = [
     "None",                      # 0: ACTION_OPT_NONE
     "Flashlight on/off",         # 1: ACTION_OPT_FLASHLIGHT
@@ -54,16 +57,20 @@ KEYACTIONS_LIST = [
     "Alarm on/off",              # 6: ACTION_OPT_ALARM
     "FM radio on/off",           # 7: ACTION_OPT_FM
     "Transmit 1750 Hz",          # 8: ACTION_OPT_1750
-    "Keylock",                   # 9: ACTION_OPT_KEYLOCK (NEW)
-    "A/B",                       # 10: ACTION_OPT_A_B (NEW)
-    "VFO/MR",                    # 11: ACTION_OPT_VFO_MR (NEW)
-    "Switch Demodulation",       # 12: ACTION_OPT_SWITCH_DEMODUL (NEW)
-    "Backlight Min Temp Off",    # 13: ACTION_OPT_BLMIN_TMP_OFF (NEW)
+    "Keylock",                   # 9: ACTION_OPT_KEYLOCK
+    "A/B",                       # 10: ACTION_OPT_A_B
+    "VFO/MR",                    # 11: ACTION_OPT_VFO_MR
+    "Switch Demodulation",       # 12: ACTION_OPT_SWITCH_DEMODUL
+    "Backlight Min Temp Off",    # 13: ACTION_OPT_BLMIN_TMP_OFF
     "Play CW MSG 1",             # 14: ACTION_OPT_PLAY_CWMSG1 (CW firmware)
     "Play CW MSG 2",             # 15: ACTION_OPT_PLAY_CWMSG2 (CW firmware)
     "Play CW MSG 3",             # 16: ACTION_OPT_PLAY_CWMSG3 (CW firmware)
     "Play CW MSG 4",             # 17: ACTION_OPT_PLAY_CWMSG4 (CW firmware)
-    "Spectrum"                   # 18: ACTION_OPT_SPECTRUM (NEW)
+    "Repeat CW MSG 1",           # 18: ACTION_OPT_REPEAT_CWMSG1 (beta3)
+    "Repeat CW MSG 2",           # 19: ACTION_OPT_REPEAT_CWMSG2 (beta3)
+    "Repeat CW MSG 3",           # 20: ACTION_OPT_REPEAT_CWMSG3 (beta3)
+    "Repeat CW MSG 4",           # 21: ACTION_OPT_REPEAT_CWMSG4 (beta3)
+    "Spectrum"                   # 22: ACTION_OPT_SPECTRUM (moved from 18)
 ]
 
 
@@ -127,36 +134,38 @@ class UVK5_NR7Y(uvk5.UVK5RadioBase):
         """Replace programmable key settings with extended action list"""
         _mem = self._memobj
         
-        # Find the key actions group
+        # Find the key actions group and its parent index
         keya = None
-        for group in rs:
+        keya_index = None
+        for i, group in enumerate(rs):
             if hasattr(group, 'get_name') and group.get_name() == 'keya':
                 keya = group
+                keya_index = i
                 break
         
         if not keya:
             LOG.warning("Could not find key actions group")
             return
         
-        # Remove existing key action settings using del
-        to_remove = []
-        for setting in list(keya):
+        # Create new RadioSettingGroup with extended actions
+        new_keya = RadioSettingGroup("keya", "Programmable keys")
+        
+        # Copy over non-key-action settings from original group
+        for setting in keya:
             if hasattr(setting, 'get_name'):
                 name = setting.get_name()
-                if 'key' in name and 'action' in name:
-                    to_remove.append(setting)
+                if 'key' not in name or 'action' not in name:
+                    # Keep non-key-action settings
+                    new_keya.append(setting)
         
-        for setting in to_remove:
-            del keya[setting]
-        
-        # Re-add with extended action list
+        # Add key action settings with extended action list
         tmpval = int(_mem.key1_shortpress_action)
         if tmpval >= len(KEYACTIONS_LIST):
             tmpval = 0
         rs_new = RadioSetting("key1_shortpress_action", "Side key 1 short press",
                           RadioSettingValueList(
                               KEYACTIONS_LIST, current_index=tmpval))
-        keya.append(rs_new)
+        new_keya.append(rs_new)
 
         tmpval = int(_mem.key1_longpress_action)
         if tmpval >= len(KEYACTIONS_LIST):
@@ -164,7 +173,7 @@ class UVK5_NR7Y(uvk5.UVK5RadioBase):
         rs_new = RadioSetting("key1_longpress_action", "Side key 1 long press",
                           RadioSettingValueList(
                               KEYACTIONS_LIST, current_index=tmpval))
-        keya.append(rs_new)
+        new_keya.append(rs_new)
 
         tmpval = int(_mem.key2_shortpress_action)
         if tmpval >= len(KEYACTIONS_LIST):
@@ -172,7 +181,7 @@ class UVK5_NR7Y(uvk5.UVK5RadioBase):
         rs_new = RadioSetting("key2_shortpress_action", "Side key 2 short press",
                           RadioSettingValueList(
                               KEYACTIONS_LIST, current_index=tmpval))
-        keya.append(rs_new)
+        new_keya.append(rs_new)
 
         tmpval = int(_mem.key2_longpress_action)
         if tmpval >= len(KEYACTIONS_LIST):
@@ -180,19 +189,12 @@ class UVK5_NR7Y(uvk5.UVK5RadioBase):
         rs_new = RadioSetting("key2_longpress_action", "Side key 2 long press",
                           RadioSettingValueList(
                               KEYACTIONS_LIST, current_index=tmpval))
-        keya.append(rs_new)
+        new_keya.append(rs_new)
         
-        # Add M key long press (stored in beep_control byte, bits 1-7)
-        beep_byte = int(_mem.beep_control)
-        tmpval = (beep_byte >> 1) & 0x7F
-        if tmpval >= len(KEYACTIONS_LIST):
-            tmpval = 0
-        rs_new = RadioSetting("key_m_longpress_action", "M key long press",
-                          RadioSettingValueList(
-                              KEYACTIONS_LIST, current_index=tmpval))
-        keya.append(rs_new)
+        # Replace old group with new one
+        rs[keya_index] = new_keya
         
-        LOG.info(f"Updated programmable keys with {len(KEYACTIONS_LIST)} actions (including M key)")
+        LOG.info(f"Updated programmable keys with {len(KEYACTIONS_LIST)} actions")
 
     def get_settings(self):
         """Get radio settings including CW if detected"""
@@ -277,12 +279,41 @@ class UVK5_NR7Y(uvk5.UVK5RadioBase):
             cw_key_input = RadioSetting(
                 "cw.key_input",
                 "Key Input Mode",
-                RadioSettingValueList(CW_KEY_INPUT_MODES, 
+                RadioSettingValueList(CW_KEY_INPUT_MODES,
                                      CW_KEY_INPUT_MODES[key_idx])
             )
             cw.append(cw_key_input)
         except Exception as e:
             LOG.error(f"Error adding key input setting: {e}")
+
+        # CW Operating Mode (beta3) - Simplified to match firmware menu (OFF/ON)
+        try:
+            oper_mode_opts = ["OFF (Normal CW)", "ON (CPO Mode)"]
+            # Firmware menu shows as binary: 0=off, 1+=on
+            oper_mode_value = self._get_cw_oper_mode()
+            oper_mode_idx = 1 if oper_mode_value > 0 else 0
+            cw_oper = RadioSetting(
+                "cw.oper_mode",
+                "CPO Mode (Practice Keyer)",
+                RadioSettingValueList(oper_mode_opts, oper_mode_opts[oper_mode_idx])
+            )
+            cw_oper.set_doc("OFF: Normal CW (instant TX). ON: CPO practice mode (sidetone only, no TX)")
+            cw.append(cw_oper)
+        except Exception as e:
+            LOG.error(f"Error adding oper mode setting: {e}")
+
+        # Message Repeat Delay (beta3)
+        try:
+            repeat_delay = self._get_cw_repeat_delay()
+            cw_repeat = RadioSetting(
+                "cw.repeat_delay",
+                "Message Repeat Delay (sec)",
+                RadioSettingValueInteger(0, 127, repeat_delay)
+            )
+            cw_repeat.set_doc("Delay between repeated CW message transmissions (0-127 seconds)")
+            cw.append(cw_repeat)
+        except Exception as e:
+            LOG.error(f"Error adding repeat delay setting: {e}")
 
         # CW Macros (4 messages)
         macros = RadioSettingGroup("cw_macros", "CW Macros")
@@ -336,14 +367,6 @@ class UVK5_NR7Y(uvk5.UVK5RadioBase):
                 _mem.key2_longpress_action = KEYACTIONS_LIST.index(str(setting.value))
                 LOG.debug(f"Set key2_longpress_action to {setting.value}")
                 continue
-            elif name == "key_m_longpress_action":
-                # M key long press stored in beep_control byte (bits 1-7)
-                action_val = KEYACTIONS_LIST.index(str(setting.value))
-                beep_byte = int(_mem.beep_control)
-                # Preserve bit 0 (beep control), set bits 1-7 (M key action)
-                _mem.beep_control = (beep_byte & 0x01) | ((action_val & 0x7F) << 1)
-                LOG.debug(f"Set key_m_longpress_action to {setting.value}")
-                continue
             
             # Handle CW settings
             if name.startswith("cw."):
@@ -369,6 +392,14 @@ class UVK5_NR7Y(uvk5.UVK5RadioBase):
                         idx = CW_KEY_INPUT_MODES.index(str(setting.value))
                         self._set_cw_key_input_idx(idx)
                         LOG.debug(f"Set key input to {setting.value}")
+                    elif name == "cw.oper_mode":
+                        # Match firmware menu behavior: OFF=0, ON=1
+                        idx = ["OFF (Normal CW)", "ON (CPO Mode)"].index(str(setting.value))
+                        self._set_cw_oper_mode(idx)  # 0=BREAK_IN, 1=CPO_RX
+                        LOG.debug(f"Set CPO mode to {setting.value}")
+                    elif name == "cw.repeat_delay":
+                        self._set_cw_repeat_delay(int(setting.value))
+                        LOG.debug(f"Set CW repeat delay to {setting.value}")
                     elif name.startswith("cw.msg"):
                         # Extract macro number from "cw.msg1" → "1"
                         # "cw.msg" is 6 chars, so number is at index 6
@@ -402,18 +433,18 @@ class UVK5_NR7Y(uvk5.UVK5RadioBase):
             # We'll just let anything else pass through by calling parent on groups
 
     def _remove_dtmf_contacts(self, rs: RadioSettings) -> None:
-        """Remove DTMF contacts group to prevent conflicts with CW macros"""
-        to_remove = []
+        """Remove DTMF contacts group to prevent conflicts"""
+        removed = []
         for group in list(rs):
             if hasattr(group, 'get_name'):
                 name = group.get_name()
-                # Remove DTMF contact group (uses same memory as CW macros)
-                if name == 'dtmfc':
-                    to_remove.append(group)
+                # Remove any DTMF contact groups
+                if 'contact' in name.lower() and 'dtmf' in name.lower():
+                    rs.remove(group)
+                    removed.append(name)
         
-        for group in to_remove:
-            rs.remove(group)
-            LOG.info(f"Removed DTMF contacts group '{group.get_name()}' (conflicts with CW macros)")
+        if removed:
+            LOG.info(f"Removed DTMF contact groups: {removed}")
 
     # ======== CW Settings Encode/Decode ========
     
@@ -491,28 +522,52 @@ class UVK5_NR7Y(uvk5.UVK5RadioBase):
         self._mmap[CW_SETTINGS_ADDR + 1] = byte1
 
     def _get_cw_key_input_idx(self) -> int:
-        """Get key input mode index (0-7)"""
+        """Get key input mode index (0-9) - beta3 stores menu index directly"""
         byte2 = struct.unpack('B', bytes(self._mmap[CW_SETTINGS_ADDR+2:CW_SETTINGS_ADDR+3]))[0]
-        if byte2 == 0xFF:
+        if byte2 == 0xFF or byte2 >= 0x80:
             return 0  # Default HandKey
-        # Formula from settings.c:238 - bits 0-4
-        val = byte2 & 0x1F
-        # Find in bitmap array
-        try:
-            return CW_KEY_INPUT_BITMAP.index(val)
-        except ValueError:
-            LOG.debug(f"Unknown key input value 0x{val:02x}, defaulting to HandKey")
+        # Beta3: bits 0-4 = menu index (0-9), bits 5-6 = oper_mode
+        menu_idx = byte2 & 0x1F
+        if menu_idx >= len(CW_KEY_INPUT_MODES):
+            LOG.debug(f"Invalid key input menu index {menu_idx}, defaulting to HandKey")
             return 0
+        return menu_idx
     
     def _set_cw_key_input_idx(self, idx: int) -> None:
-        """Set key input mode from index"""
-        if idx < 0 or idx >= len(CW_KEY_INPUT_BITMAP):
+        """Set key input mode from index - beta3 stores menu index directly"""
+        if idx < 0 or idx >= len(CW_KEY_INPUT_MODES):
             idx = 0
-        val = CW_KEY_INPUT_BITMAP[idx]
-        # Update bits 0-4, preserve bits 5-7
         byte2 = struct.unpack('B', bytes(self._mmap[CW_SETTINGS_ADDR+2:CW_SETTINGS_ADDR+3]))[0]
-        byte2 = (byte2 & 0xE0) | (val & 0x1F)
-        self._mmap[CW_SETTINGS_ADDR + 2] = byte2
+        # Preserve bits 5-6 (oper_mode), set bits 0-4 (menu index)
+        oper_mode = (byte2 >> 5) & 0x03
+        self._mmap[CW_SETTINGS_ADDR + 2] = (idx & 0x1F) | (oper_mode << 5)
+
+    def _get_cw_oper_mode(self) -> int:
+        """Get CW operating mode (0=Break-in, 1=CPO+RX, 2=CPO+mute) - beta3"""
+        byte2 = struct.unpack('B', bytes(self._mmap[CW_SETTINGS_ADDR+2:CW_SETTINGS_ADDR+3]))[0]
+        if byte2 == 0xFF or byte2 >= 0x80:
+            return 0  # Default Break-in
+        return (byte2 >> 5) & 0x03
+    
+    def _set_cw_oper_mode(self, mode: int) -> None:
+        """Set CW operating mode (0-2) - beta3"""
+        mode = max(0, min(2, mode))
+        byte2 = struct.unpack('B', bytes(self._mmap[CW_SETTINGS_ADDR+2:CW_SETTINGS_ADDR+3]))[0]
+        # Preserve bits 0-4 (key input), set bits 5-6 (oper mode)
+        key_input = byte2 & 0x1F
+        self._mmap[CW_SETTINGS_ADDR + 2] = key_input | (mode << 5)
+
+    def _get_cw_repeat_delay(self) -> int:
+        """Get CW message repeat delay in seconds (0-127) - beta3"""
+        byte3 = struct.unpack('B', bytes(self._mmap[CW_SETTINGS_ADDR+3:CW_SETTINGS_ADDR+4]))[0]
+        if byte3 >= 0x80:  # High bit set = invalid
+            return 4  # Default 4 seconds
+        return byte3 & 0x7F
+    
+    def _set_cw_repeat_delay(self, delay: int) -> None:
+        """Set CW message repeat delay (0-127 seconds) - beta3"""
+        delay = max(0, min(127, delay))
+        self._mmap[CW_SETTINGS_ADDR + 3] = delay & 0x7F
 
     # ======== CW Macro Encode/Decode ========
     


### PR DESCRIPTION
- Fix AttributeError in _update_key_actions(): RadioSettingGroup doesn't support item deletion, now creates new group instead
- Update CPO Mode setting to match firmware menu behavior (OFF/ON instead of 3 modes)
- Align with firmware: OFF = Normal CW (BREAK_IN), ON = CPO Mode (CPO_RX)
- Tested and verified working correctly with NR7Y beta3 firmware