### PR TITLE
Beta7

### DIFF
--- a/NR7Y_FIRMWARE_README.md
+++ b/NR7Y_FIRMWARE_README.md
@@ -6,13 +6,167 @@ NR7Y CW firmware README
 > 
 > If the flashing process doesn't work, you know you don't have a V1. You should still be able to flash back to the original factory firmware; online sources have it available. I will work on a V2/V3 compatible version of the firmware soon. Note: Bootloader version is not the same as radio hardware version; it's ok if you see "bootloader version 2.xx" during flashing.
 
-Upload using your favorite Quansheng flash tool. I use k5tool (https://github.com/qrp73/K5TOOL). This link also has recovery information on the landing README page, if needed. The web-based https://egzumer.github.io/uvtools/ works well too, but Chrome-only.
+Upload using your favorite Quansheng flash tool. I use k5tool (https://github.com/qrp73/K5TOOL). This link also has recovery information on the landing README page, if needed. 
+
+To flash directly from your Chrome browser use https://egzumer.github.io/uvtools/.
 
 > [!NOTE]
 > After flashing, I *strongly advise* resetting the eeprom to ensure there are no lingering settings from other firmware versions. 
  1. Hold down PTT and Side Button 1 while turning the radio on.
  2. Release buttons, menu will be automatically presented.
  3. Go up to Reset and pick ALL. 
+
+## Changelist from beta6 -> beta7 (1.0)
+- Status bar shows **BKIN** indicator when CW break-in is enabled
+- Add several punctuation characters to the on-screen CW decoder and macro system (`.`, `,`, `=`, `-`)
+- 3ms debounce added to CW key inputs to reduce spurious elements from contact noise and RFI
+- Fixed a bug where ADC-read (CEC cable test) mode would trigger RF transmission (#23)
+- Re-apply monitor-mode setting based on modulation when the VFO is reconfigured such going between VFO A/B or mem to VFO mode
+- Add a short pre-delay when beginning to send while the squelch is closed (audio path off), preventing the leading edge of the first dit from being cut off
+- Minor ADC read cleanup
+
+_Previous beta changelists moved to the bottom of this doc_
+
+# CW (Morse Code) Firmware Mod Guide
+
+This guide describes the CW (Continuous Wave / Morse Code) menu options added to the UV-K5 firmware when `ENABLE_CW_MODULATOR` is enabled.
+
+## Accessing CW Mode
+
+1. Set your VFO modulation to **CW** mode (in the modulation menu), or long-press **0 (FM)** to change modulations
+2. Configure CW parameters in the menu system (Menu > CWfreq, CWvol, etc.)
+3. Press PTT is a CW straight key by default
+
+## Iambic Key Options
+
+You can perform keying in these ways:
+- Buttons (PTT and Side Button 1)
+- Perform a small rework inside the radio, then attach a normal paddle - rework instructions: [NR7Y CW Firmware - Paddle Rework.pdf](<NR7Y CW Firmware - Paddle Rework.pdf>)
+- Build a "CEC cable" with 2 resistors, and use the cable on a normal paddle - example cable instructions: (https://www.m5duk.com/2025/05/20/use-a-standard-cw-paddle-on-a-quansheng-uv-k5-uv-k6/)
+
+## Code Practice Oscillator (CPO)
+
+The CPO mode provides local practice: no RX or TX, sidetone only, on-screen decode while you send.
+- Launch by holding **5** (NOAA reception is disabled)
+- Exit by tapping **EXIT**
+- Use the Up/Down keys to adjust WPM, which will save on exit.
+- Tap **'*'** to toggle backlight
+- Tap **4** to toggle flashlight sending
+
+### Filtering
+
+Menu option #9 (Filter) includes an extra setting for 1.7k bandwidth. Cycle through filter settings by holding ***7***
+
+## CW Menu Options
+
+#### `CWfreq` - CW Sidetone Frequency
+
+Sets the audio frequency for the CW sidetone you hear locally when transmitting. This is also used as the BFO (Beat Frequency Oscillator) offset when receiving CW signals.
+
+#### `CWvol` - CW Sidetone Volume Level
+
+Controls the volume level of the CW sidetone you hear when transmitting. The lowest value is "OFF"
+
+#### `CWkmod` - CW Keyer Mode
+
+Selects the keyer mode when using paddle inputs (dual-lever key). These modes are modeled after Elecraft mode A/B behavior. 
+
+**Note:** Keyer mode only applies when using paddle inputs (buttons or port paddles). When using handkey modes, the keyer is disabled and this setting has no effect.
+
+#### `CWwpm` - CW Speed (Words Per Minute)
+
+Sets the sending speed for the automatic iambic keyer in Words Per Minute.
+
+**Note:** Speed only applies when using paddle inputs with the iambic keyer enabled. Handkey modes follow your manual keying speed.
+
+#### `CWkin` - CW Key Input Configuration
+
+Configures how the CW input signals are connected and interpreted. This is the most complex setting as it determines which physical inputs are used and how they're mapped.
+
+**Note:** The port modes (PTT+port, tip/ring settings) require an iambic key rework inside the radio. If you have already done the original straight key mod and wish to keep it, this will continue to work with the "PTT HandKey" mode or PTT/Side1 modes.
+
+**Note:** When the radio is in a port/tip/ring or CEC mode, serial communication **will not work**, including programming with CHIRP. To use the serial port, switch modulation mode away from CW, or switch to a VFO where CW is not the current mode. This does not affect firmware flash programming.
+
+**CEC cable input** is now available here. Because of the internal way this is accomplished, the PTT button cannot be used while in this mode. To make your own CEC cable, see [https://www.m5duk.com/2025/05/20/use-a-standard-cw-paddle-on-a-quansheng-uv-k5-uv-k6/](M5DUK's Helpful Article) among others. In short, wire a cable where the paddle tip goes through a 10k resistor to radio tip, and paddle ring goes through a 20k resistor **also** to radio tip, and wire sleeve-to-sleeve.
+
+#### `CWmsg1` / `CWmsg2` / `CWmsg3` / `CWmsg4` - CW Message Recording and Playback
+
+Messages 1-4 may store up to 46 characters for playback (not including spaces).
+
+Messages start empty - enter the menu and use arrows to change macro option:
+- record new? - Select with 'menu' button to begin recording
+- play - Select with 'menu' button to begin playback
+
+### CW Message Recording
+- Recordings are made using the currently programmed keyer settings and wpm. Attempting to record while not in CW modulation or without a keyer (while in handkey mode) will not work.
+- RF is not transmitted while recording. 
+- While recording is in progress, the display will show the most recently recorded characters, and a macro character count. 
+- To save the macro when complete, Push the 'menu' button. 
+- To exit the recording without saving, push the 'exit' button.
+
+### CW Message Playback
+There are two ways to playback the CW messages:
+- Enter the menu selection for the given message, and change using up/down to 'Play', then select with 'menu' button. Playback will begin. Change using up/down to 'Repeat' and select with the 'menu' button to start repeating the message.
+- Assign playback to an action button (side buttons or Menu button):
+  - In the menu system choose one of menu items 23 through 27 to assign playback or repeat to side button 1 or 2 short press, 1 or 2 long press, or Menu button long press. Keep in mind that Side Button 1 is unavailable for macro sending when set as a keyer button. The assigned action is ignored.
+  - After choosing the button menu item, from the action list pick "PLAY CW MSG1/2/3/4" to play the message one time for each button push, or pick "REPEAT CW MSG1/2/3/4" to activate a repeating playback for the given message.
+- During message playback, the display will show the characters being sent, and a flashing arrow on the left side to indicate a message is being played. If Repeat mode is activated, the message will begin sending again after the delay time has expired.
+- Message playback can be interrupted by tapping a keyer key or any keyboard key. This will also stop repeating.
+
+#### `CWmrpt` - CW Message Repeat
+
+Selects number of seconds to delay before sending the message again, when in repeat.
+
+#### `CWbkin` - CW Break-In
+
+Controls break-in. When OFF, RF TX is blocked but sidetone still plays so you can hear yourself key while monitoring RX. When BKIN is active, RF will send on keying. An indicator is displayed at the top of the screen (and the radio will enter TX mode and light the red LED when sending).
+
+#### `CWcrd` - ADC Read Check (hidden menu)
+**(in the hidden tech menu - turn on radio while holding PTT and SIDE1 to access)**
+
+Shows the live ADC reading from the 3.5mm port for CEC cable tuning. Use this to measure your 10k and 20k resistors if you are having problems detecting keys properly. Enter this mode and hold down each paddle key separately to see the readings, which update every half second (holding both keys at once will show a third reading, which is not useful). Capture the two paddle readings, then set the values in the below 20k/10k menus.
+
+#### `CWcLo` / `CWcHi` - CEC ADC thresholds (hidden menu)
+**(in the hidden tech menu - turn on radio while holding PTT and SIDE1 to access)**
+
+Set the ADC thresholds for your CEC cable. After capturing values with the Read Check, store the higher number in CWcHi, and the lower in CWcLo.
+
+**Note:** Please file an issue if the detected values are significantly different than the defaults. Field reports may help tune these best.
+
+#### Menu `CWkin` Input Options In Detail:
+
+**1. PTT HandKey** (Default)
+- Use PTT button as a straight key
+
+**2. PTT+port HandKey**
+- PTT button as CW key (straight key mode)
+- Also accepts a straight key in the 3.5mm port (with iambic rework)
+
+**Note:** _Each of the options below has a primary (dah/dit) and reversed (dit/dah) version - set how you prefer_
+
+**PTT dah SD1 dit / PTT dit SD1 dah** (Buttons)
+- PTT sends dah or dit
+- Side button 1 (SD1) = sends dit or dah
+- Automatic iambic keyer enabled (for this and all the below options)
+
+**PTT+tip dah/dah, ring dit/dah** (Reworked Port)
+- 3.5mm port TIP or PTT button sends one element
+- 3.5mm port RING pin sends other element
+- Requires the internal rework
+- Leaves SD1 button free for other use
+
+**PTT+tip dah/dit, SD1+ring dit/dit** (Reworked port and Buttons)
+- PTT OR Tip = DAH/dit
+- Side button 1 (SD1) OR Ring = DIT/dah
+- Both radio buttons AND external port paddles work simultaneously
+
+**9. CEC Cable**
+- ADC-based input using a CEC cable. The PTT button is ignored in this mode.
+
+**10. CEC Cable Reversed**
+- Same as above with paddle orientation reversed.
+
+# Prior Beta Changelists
 
 ## Changelist from beta5 -> beta6
 - Monitor mode is available in CW/SSB - these modes default to monitor on / squelch open. If a button is mapped to MONITOR, it can be used to close the squelch. This works inverse to FM mode. If modulation is changed away and back to CW/SSB, squelch will be back open again (not saved).
@@ -63,154 +217,3 @@ Beta3 was not very healthy. If you had CEC cable mode set, and turned the radio 
 - Don't allow setting a port-based keyer mode if no rework or if keys appear stuck
 - Fix keyer menu naming "sleeve" -> "ring" for port
 - Main screen: show RSSI signal bar in RX mode instead of AGC debug data
-
-# CW (Morse Code) Firmware Mod Guide
-
-This guide describes the CW (Continuous Wave / Morse Code) menu options added to the UV-K5 firmware when `ENABLE_CW_MODULATOR` is enabled.
-
-## Accessing CW Mode
-
-1. Set your VFO modulation to **CW** mode (in the modulation menu), or long-press **0 (FM)** to change modulations
-2. Configure CW parameters in the menu system (Menu > CWfreq, CWvol, etc.)
-3. Press PTT is a CW straight key by default
-
-## Code Practice Oscillator (CPO)
-
-The CPO mode provides local practice: no RX or TX, sidetone only, on-screen decode while you send.
-- Launch by holding **5** (NOAA reception is disabled)
-- Exit by tapping **EXIT**
-- Use the Up/Down keys to adjust WPM, which will save on exit.
-- Tap **'*'** to keep the backlight on/off
-- Tap **4** to enable/disable flashlight sending
-
-### Filtering
-
-Menu option #9 (Filter) includes an extra setting for 1.7k. Might be the best we can do on this transciever.
-
-## CW Menu Options
-
-#### CWfreq - CW Sidetone Frequency
-
-Sets the audio frequency for the CW sidetone you hear locally when transmitting. This is also used as the BFO (Beat Frequency Oscillator) offset when receiving CW signals.
-
-#### CWvol - CW Sidetone Volume Level
-
-Controls the volume level of the CW sidetone you hear when transmitting. The lowest value is "OFF"
-
-#### CWkmod - CW Keyer Mode
-
-Selects the keyer mode when using paddle inputs (dual-lever key). These modes are modeled after Elecraft mode A/B behavior. 
-
-**Note:** Keyer mode only applies when using paddle inputs (buttons or port paddles). When using handkey modes, the keyer is disabled and this setting has no effect.
-
-#### CWwpm - CW Speed (Words Per Minute)
-
-Sets the sending speed for the automatic iambic keyer in Words Per Minute.
-
-**Note:** Speed only applies when using paddle inputs with the iambic keyer enabled. Handkey modes follow your manual keying speed.
-
-#### CWkin - CW Key Input Configuration
-
-Configures how the CW input signals are connected and interpreted. This is the most complex setting as it determines which physical inputs are used and how they're mapped.
-
-**Note:** The port modes (PTT+port, tip/ring settings) require an iambic key rework inside the radio. If you have already done the original straight key mod and wish to keep it, this will continue to work with the "PTT HandKey" mode or PTT/Side1 modes.
-
-**Note:** When the radio is in a port/tip/ring or CEC mode, serial communication **will not work**, including programming with CHIRP. To use the serial port, switch modulation mode away from CW, or switch to a VFO where CW is not the current mode. This does not affect firmware flash programming.
-
-**CEC cable input** is now available here. Because of the internal way this is accomplished, the PTT button cannot be used while in this mode. To make your own CEC cable, see [https://www.m5duk.com/2025/05/20/use-a-standard-cw-paddle-on-a-quansheng-uv-k5-uv-k6/](M5DUK's Helpful Article) among others. In short, wire a cable where the paddle tip goes through a 10k resistor to radio tip, and paddle ring goes through a 20k resistor **also** to radio tip, and wire sleeve-to-sleeve.
-
-#### CWmsg1 / CWmsg2 / CWmsg3 / CWmsg4 - CW Message Recording and Playback
-
-Messages 1-4 may store up to 46 characters for playback (not including spaces).
-
-Messages start empty - enter the menu and use arrows to change macro option:
-- record new? - Select with 'menu' button to begin recording
-- play - Select with 'menu' button to begin playback
-
-### CW Message Recording
-- Recordings are made using the currently programmed keyer settings and wpm. Attempting to record while not in CW modulation or without a keyer (while in handkey mode) will not work.
-- RF is not transmitted while recording. 
-- While recording is in progress, the display will show the most recently recorded characters, and a macro character count. 
-- To save the macro when complete, Push the 'menu' button. 
-- To exit the recording without saving, push the 'exit' button.
-
-### CW Message Playback
-There are two ways to playback the CW messages:
-- Enter the menu selection for the given message, and change using up/down to 'Play', then select with 'menu' button. Playback will begin. Change using up/down to 'Repeat' and select with the 'menu' button to start repeating the message.
-- Assign playback to an action button (side buttons or Menu button):
-  - In the menu system choose one of menu items 23 through 27 to assign playback or repeat to side button 1 or 2 short press, 1 or 2 long press, or Menu button long press. Keep in mind that Side Button 1 is unavailable for macro sending when set as a keyer button. The assigned action is ignored.
-  - After choosing the button menu item, from the action list pick "PLAY CW MSG1/2/3/4" to play the message one time for each button push, or pick "REPEAT CW MSG1/2/3/4" to activate a repeating playback for the given message.
-- During message playback, the display will show the characters being sent, and a flashing arrow on the left side to indicate a message is being played. If Repeat mode is activated, the message will begin sending again after the delay time has expired.
-- Message playback can be interrupted by tapping a keyer key or any keyboard key. This will also stop repeating.
-
-#### CWmrpt - CW Message Repeat
-
-Selects number of seconds to delay before sending the message again, when in repeat.
-
-#### CWbkin - CW Break-In
-
-Controls break-in. When OFF, RF TX is blocked but sidetone still plays so you can hear yourself key while monitoring RX.
-
-#### CWcrd - ADC Read Check (hidden menu)
-**(in the hidden tech menu - turn on radio while holding PTT and SIDE1 to access)**
-
-Shows the live ADC reading from the 3.5mm port for CEC cable tuning. Use this to measure your 10k and 20k resistors if you are having problems detecting keys properly. Enter this mode and hold down each paddle key separately to see the readings, which update every half second (holding both keys at once will show a third reading, which is not useful). Capture the two paddle readings, then set the values in the below 20k/10k menus.
-
-#### CWcLo / CWcHi - CEC ADC thresholds (hidden menu)
-**(in the hidden tech menu - turn on radio while holding PTT and SIDE1 to access)**
-
-Set the ADC thresholds for your CEC cable. After capturing values with the Read Check, store the higher number in CWcHi, and the lower in CWcLo.
-
-**Note:** Please file an issue if the detected values are significantly different than the defaults. Field reports may help tune these best.
-
-#### Input Options Explained:
-
-**1. PTT HandKey** (Default)
-- Use PTT button as a straight key
-
-**2. PTT+port HandKey**
-- PTT button as CW key (straight key mode)
-- Also accepts a straight key in the 3.5mm port (with iambic rework)
-
-**3. PTT dah, SD1 dit** (Buttons Normal)
-- PTT = DAH (long element)
-- Side button 1 (SD1) = DIT (short element)
-- Automatic iambic keyer enabled
-
-**4. PTT dit, SD1 dah** (Buttons Reversed)
-- PTT = DIT (short element)
-- Side button 1 (SD1) = DAH (long element)
-- Automatic iambic keyer enabled
-- **Reversed paddle orientation** (for left-handed operators or personal preference)
-
-**5. PTT+tip dah, ring dit** (Port Normal)
-- 3.5mm port TIP or PTT button = DAH
-- 3.5mm port RING = DIT
-- Automatic iambic keyer enabled
-
-**6. PTT+tip dit, ring dah** (Port Reversed)
-- 3.5mm port TIP or PTT button = DIT
-- 3.5mm port RING = DAH
-- Automatic iambic keyer enabled
-- **Reversed paddle orientation**
-
-**7. PTT+tip dah, SD1+ring dit** (Both Normal)
-- PTT OR Tip = DAH
-- Side button 1 (SD1) OR Ring = DIT
-- Automatic iambic keyer enabled
-- Both radio buttons AND external port paddles work simultaneously
-
-**8. PTT+tip dit, SD1+ring dah** (Both Reversed)
-- PTT OR Tip = DIT
-- Side button 1 (SD1) OR Ring = DAH
-- Automatic iambic keyer enabled
-- Both radio buttons AND external port paddles work simultaneously
-- **Reversed paddle orientation**
-
-**9. CEC Cable**
-- ADC-based input using a CEC cable. The PTT button is ignored in this mode.
-
-**10. CEC Cable Reversed**
-- Same as above with paddle orientation reversed.
-
-**Last Updated**: January 31, 2026

--- a/NR7Y_FIRMWARE_README.md
+++ b/NR7Y_FIRMWARE_README.md
@@ -2,7 +2,7 @@ NR7Y CW firmware README
 
 # Beta5
 > [!IMPORTANT]
-> This firmware only works on "V1" firmware. How do you know? Well, you kinda don't. If you bought your radio early last year, it's V1. If you bought it late last year, it could be V2. If you bought it in 2026, it could be V3! Most (all?) V3 radios are marked as such on the label under the battery.
+> This firmware only works on "V1" hardware. How do you know? Well, you kinda don't. If you bought your radio early last year, it's V1. If you bought it late last year, it could be V2. If you bought it in 2026, it could be V3! Most (all?) V3 radios are marked as such on the label under the battery. Some vendors specifically promote that their listing a V3, but not all.
 > 
 > If the flashing process doesn't work, you know you don't have a V1. You should still be able to flash back to the original factory firmware; online sources have it available. I will work on a V2/V3 compatible version of the firmware soon. Note: Bootloader version is not the same as radio hardware version; it's ok if you see "bootloader version 2.xx" during flashing.
 

--- a/app/app.c
+++ b/app/app.c
@@ -1953,6 +1953,8 @@ Skip:
 
 #ifdef ENABLE_CW_MODULATOR
 		CW_KeyerReconfigure(gTxVfo->Modulation==MODULATION_CW);
+		gMonitor = (gRxVfo->Modulation == MODULATION_CW ||
+		            gRxVfo->Modulation == MODULATION_USB);
 #endif
 
 #ifdef ENABLE_NOAA

--- a/app/cwapp.c
+++ b/app/cwapp.c
@@ -83,6 +83,9 @@ void CW_AppUpdate(void)
 	if (gF_LOCK)  // don't init or run the keyer in "hidden menu" tech mode
 		return;
 
+	if (gCW_AdcReadActive)  // CW_CRD mode: PTT pin is an output; no keyer FSM activity
+		return;
+
 	if (!(gTxVfo->Modulation == MODULATION_CW
 #ifdef ENABLE_CODE_PRACTICE
 		|| gCW_CpoActive

--- a/app/cwapp.c
+++ b/app/cwapp.c
@@ -117,18 +117,22 @@ void CW_AppUpdate(void)
 		switch (action)
 		{
 			case CW_ACTION_CARRIER_ON:
-				BK4819_SetAF(BK4819_AF_ALAM);
-				BK4819_WriteRegister(BK4819_REG_70,
-					BK4819_REG_70_ENABLE_TONE1 |
-					(gEeprom.CW_SIDETONE_LEVEL << BK4819_REG_70_SHIFT_TONE1_TUNING_GAIN));
-				BK4819_SetScrambleFrequencyControlWord(gEeprom.CW_TONE_FREQUENCY * 10);
-				#ifdef ENABLE_FLASHLIGHT
-				if (gCW_FlashlightSending) {
-					GPIO_SetBit(&GPIOC->DATA, GPIOC_PIN_FLASHLIGHT);
-				}
-				#endif
-				gCW_TxDisplayHoldoff_10ms = 200;
-			break;
+			if (gCW_State == CW_INACTIVE && !AUDIO_IsAudioPathOn()) {
+				AUDIO_AudioPathOn();
+				SYSTEM_DelayMs(10);
+			}
+			BK4819_SetAF(BK4819_AF_ALAM);
+			BK4819_WriteRegister(BK4819_REG_70,
+				BK4819_REG_70_ENABLE_TONE1 |
+				(gEeprom.CW_SIDETONE_LEVEL << BK4819_REG_70_SHIFT_TONE1_TUNING_GAIN));
+			BK4819_SetScrambleFrequencyControlWord(gEeprom.CW_TONE_FREQUENCY * 10);
+			#ifdef ENABLE_FLASHLIGHT
+			if (gCW_FlashlightSending) {
+				GPIO_SetBit(&GPIOC->DATA, GPIOC_PIN_FLASHLIGHT);
+			}
+			#endif
+			gCW_TxDisplayHoldoff_10ms = 200;
+		break;
 
 			case CW_ACTION_CARRIER_OFF:
 				BK4819_SetScrambleFrequencyControlWord(0);
@@ -161,6 +165,11 @@ void CW_AppUpdate(void)
 
 			if (gCW_State == CW_INACTIVE)
 			{
+				if(!AUDIO_IsAudioPathOn())
+				{
+					AUDIO_AudioPathOn();
+					SYSTEM_DelayMs(20);
+				}
 				RADIO_PrepareTX();
 			}
 			else if (gCW_State == CW_SUSPENDED) {

--- a/app/cwapp.c
+++ b/app/cwapp.c
@@ -121,6 +121,7 @@ void CW_AppUpdate(void)
 				AUDIO_AudioPathOn();
 				SYSTEM_DelayMs(10);
 			}
+			BACKLIGHT_TurnOn();
 			BK4819_SetAF(BK4819_AF_ALAM);
 			BK4819_WriteRegister(BK4819_REG_70,
 				BK4819_REG_70_ENABLE_TONE1 |
@@ -161,7 +162,8 @@ void CW_AppUpdate(void)
 		case CW_ACTION_CARRIER_ON:
 			gTxTimerCountdown_500ms = 0;
 			gCW_TxDisplayHoldoff_10ms = 200;
-			gPttIsPressed = true;  // makes backlight come on, among other things
+			gPttIsPressed = true;
+			BACKLIGHT_TurnOn();
 
 			if (gCW_State == CW_INACTIVE)
 			{

--- a/app/cwhardware.c
+++ b/app/cwhardware.c
@@ -44,9 +44,11 @@
     #define CW_KEYER_RING_GPIO_BIT GPIOB_PIN_SWD_IO
 #endif
 
-// Local state for last sampled paddles (edge detection)
-static bool s_last_dit = false;
-static bool s_last_dah = false;
+// Local state for debounce counters and debounced edge tracking
+static bool     s_last_dit   = false;
+static bool     s_last_dah   = false;
+static uint32_t s_dit_count  = 0;  // consecutive raw-true reads for dit
+static uint32_t s_dah_count  = 0;  // consecutive raw-true reads for dah
 
 // Read button ring input (SIDE1)
 static void CW_ReadSideButton(bool *ring_out)
@@ -93,11 +95,11 @@ static bool CW_ReadGpioDeglitched(volatile uint32_t *gpio_data, uint8_t pin_bit,
     bool result = false;
     uint16_t reg = 0, reg2;
     unsigned int i, k;
-    uint32_t limit = heavy ? 500 : 100; // more samples for heavy de-noise
-    uint32_t goal = heavy ? 300 : 60;  // need this many stable samples
+    uint32_t limit = heavy ? 250 : 50; // more samples for heavy de-noise
+    uint32_t goal = heavy ? 150 : 30;  // need this many stable samples
 
     for (i = 0, k = 0, reg = 0; i < goal && k < limit; i++, k++) {
-        SYSTICK_DelayUs(10);
+        SYSTICK_DelayUs(5);
         reg2 = (*gpio_data) & (1U << pin_bit);
         i *= (reg == reg2);  // Reset i if readings differ
         reg = reg2;
@@ -231,14 +233,24 @@ void CW_ReadKeys(CW_Input *in)
         n_dah = false;
     }
 
-    // Compute edges
-    in->dit_rise = (!s_last_dit && n_dit);
-    in->dah_rise = (!s_last_dah && n_dah);
-    in->dit = n_dit;
-    in->dah = n_dah;
+    // Three-strike debounce: increment static counters while the raw line is
+    // active, reset to zero as soon as it goes inactive.
+    if (n_dit) s_dit_count++; else s_dit_count = 0;
+    if (n_dah) s_dah_count++; else s_dah_count = 0;
 
-    s_last_dit = n_dit;
-    s_last_dah = n_dah;
+    // Debounced state: line is considered active only after 3 consecutive hits.
+    bool deb_dit = (s_dit_count >= 3);
+    bool deb_dah = (s_dah_count >= 3);
+
+    // Edges are computed against the previous debounced state so callers only
+    // see a rising edge on the debounced false->true transition.
+    in->dit_rise = (!s_last_dit && deb_dit);
+    in->dah_rise = (!s_last_dah && deb_dah);
+    in->dit      = deb_dit;
+    in->dah      = deb_dah;
+
+    s_last_dit = deb_dit;
+    s_last_dah = deb_dah;
 }
 
 // Configure port ground pin (PA8) for tip/ring paddle input
@@ -346,6 +358,8 @@ void CW_ConfigureADCforCECPaddles(bool enable)
 // Reset sampled key states (used from keyer init)
 void CW_HW_ResetKeySamples(void)
 {
-    s_last_dit = false;
-    s_last_dah = false;
+    s_last_dit  = false;
+    s_last_dah  = false;
+    s_dit_count = 0;
+    s_dah_count = 0;
 }

--- a/app/cwhardware.c
+++ b/app/cwhardware.c
@@ -97,7 +97,7 @@ static bool CW_ReadGpioDeglitched(volatile uint32_t *gpio_data, uint8_t pin_bit,
     uint32_t goal = heavy ? 300 : 60;  // need this many stable samples
 
     for (i = 0, k = 0, reg = 0; i < goal && k < limit; i++, k++) {
-        SYSTICK_DelayUs(1);
+        SYSTICK_DelayUs(10);
         reg2 = (*gpio_data) & (1U << pin_bit);
         i *= (reg == reg2);  // Reset i if readings differ
         reg = reg2;

--- a/app/cwhardware.c
+++ b/app/cwhardware.c
@@ -135,29 +135,21 @@ static void CW_ReadPtt(bool *ptt_out)
 uint16_t CW_ReadCH3()
 {    
     ADC_Start();
-    while (!ADC_CheckEndOfConversion(ADC_CH3)) {}
+    while (!ADC_CheckEndOfConversion(ADC_CH9)){} // ADC_CH3)) {}
     return ADC_GetValue(ADC_CH3);
 }
 
 
 static void CW_ReadADCkeys(bool *tip_out, bool *ring_out)
 {
-    // Take baseline ADC sample with timing
-    // uint16_t start_tick = timer_jiffies();
-    
-    // being absolutely paranoid about performance, we enable only CH3 for this loop, then set back
-    uint32_t regval = SARADC_CFG;
-    SARADC_CFG = (regval & ~SARADC_CFG_CH_SEL_MASK) | (ADC_CH3 << SARADC_CFG_CH_SEL_SHIFT);
-
     uint16_t baseline = CW_ReadCH3();
 
     // Validate with up to 4 more samples - stop if any differs by >40 from baseline
     uint16_t val = baseline;
-    int samples_taken = 1;
     
     for (int i = 0; i < 12; i++) {
         uint16_t sample = CW_ReadCH3();
-        samples_taken++;
+        //samples_taken++;
         
         int16_t diff = (int16_t)sample - (int16_t)baseline;
         if (diff < 0) diff = -diff;
@@ -168,13 +160,6 @@ static void CW_ReadADCkeys(bool *tip_out, bool *ring_out)
             SYSTICK_DelayUs(5);  // Short delay before next sample
         }
     }
-    SARADC_CFG = regval;  // Restore original channel config so battery monitoring etc. still works
-    
-    // uint16_t elapsed = timer_jiffies_since(start_tick);
-    // Log timing and validation
-    // char log_buf[64];
-    // sprintf(log_buf, "ADC: %u jiffies, %d samples, baseline=%u->%u\r\n", elapsed, samples_taken, baseline, val);
-    // UART_LogSend(log_buf, strlen(log_buf));
 
     if (val < gEeprom.CW_ADC_CABLE_20K - CW_ADC_RANGE_LIMIT || val > CW_ADC_MAX) return;  // no paddle pressed or fault
     else if (val < gEeprom.CW_ADC_CABLE_20K + CW_ADC_RANGE_LIMIT) *ring_out = true;  // 20k ohm

--- a/app/cwkeyer.c
+++ b/app/cwkeyer.c
@@ -77,8 +77,7 @@ static bool           s_active_is_dit = false;
 static bool           s_pending_alternate = false; // alternate element queued
 /* last sampled paddles moved to app/cwhardware.c */
 static bool           s_last_handkey_ptt = false; // last PTT state for handkey mode
-
-// Macro playback state
+static uint16_t       s_elem_deadline_extra_ms = 0; // extra ms added to first-element deadline when audio path must be opened
 static char s_playback_buf[CW_MACRO_MAX_LEN * 2 + 1]; // decoded with spaces inserted
 static uint16_t s_playback_buf_len = 0; // strlen of the buffer
 static uint16_t s_playback_pos = 0; // index into playback buffer
@@ -606,6 +605,7 @@ CW_Action_t CW_HandleState(void)
 
             s_pending_alternate = false;
             s_elem_start_count = cur_count;
+            s_elem_deadline_extra_ms = AUDIO_IsAudioPathOn() ? 0 : 20;
             s_KeyerFSMState = CWK_STATE_ACTIVE_ELEMENT;
 #if CW_KEYER_DEBUG
             UART_Send("keyer going active\r\n", 20);
@@ -663,7 +663,8 @@ CW_Action_t CW_HandleState(void)
             }
         }
 
-        if (elapsed_elem >= target) {
+        if (elapsed_elem >= target + s_elem_deadline_extra_ms) {
+            s_elem_deadline_extra_ms = 0;
             action = CW_ACTION_CARRIER_OFF;
             s_elem_start_count = cur_count;
             // Emit element to encoder on state exit

--- a/app/cwmacro.c
+++ b/app/cwmacro.c
@@ -80,6 +80,10 @@ static const MorseCode_t MORSE_TABLE[] = {
 	// Punctuation
 	{'/', 5, 0b01001},    // -..-.
 	{'?', 6, 0b001100},    // ..--..
+	{'.', 6, 0b010101},    // .-.-.-
+	{',', 6, 0b110011},    // --..--
+	{'=', 6, 0b10001},      // -...-
+	{'-', 6, 0b100001}     // -....-
 };
 
 #define MORSE_TABLE_SIZE (sizeof(MORSE_TABLE) / sizeof(MORSE_TABLE[0]))

--- a/app/menu.c
+++ b/app/menu.c
@@ -1676,6 +1676,7 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld)
 		if (UI_MENU_GetCurrentMenuId() == MENU_CW_CRD)
 		{
 			CW_KeyerReconfigure(false);  // halt the keyer
+			gCW_KeyerManagesPtt = true;   // block normal PTT path while PTT pin is reconfigured as output
 			CW_ConfigureADCforCECPaddles(true);
 			gCW_AdcReadActive = true;
 			edit_index = 0;  // Use edit_index >= 0 to signal read mode

--- a/audio.h
+++ b/audio.h
@@ -141,6 +141,10 @@ static inline void AUDIO_AudioPathOff(void) {
 	GPIO_ClearBit(&GPIOC->DATA, GPIOC_PIN_AUDIO_PATH);
 }
 
+static inline bool AUDIO_IsAudioPathOn(void) {
+	return GPIO_CheckBit(&GPIOC->DATA, GPIOC_PIN_AUDIO_PATH) != 0;
+}
+
 #ifdef ENABLE_VOICE
 	extern VOICE_ID_t        gVoiceID[8];
 	extern uint8_t           gVoiceReadIndex;

--- a/bitmaps.c
+++ b/bitmaps.c
@@ -165,6 +165,37 @@ const uint8_t BITMAP_F_Key[6] =
 	};
 #endif
 
+#ifdef ENABLE_CW_MODULATOR
+	const uint8_t BITMAP_BKIN[18] =
+	{	// "BKIN" - CW break-in indicator
+		0b00000000,
+		// B (4 cols)
+		0b01111111,
+		0b01001001,
+		0b01001001,
+		0b00110110,
+		// gap
+		0b00000000,
+		// K (4 cols)
+		0b01111111,
+		0b00010100,
+		0b00100010,
+		0b01000001,
+		// gap
+		0b00000000,
+		// I (1 col)
+		0b01111111,
+		// gap
+		0b00000000,
+		// N (5 cols)
+		0b01111111,
+		0b00000100,
+		0b00001000,
+		0b00010000,
+		0b01111111
+	};
+#endif
+
 
 // 'XB' (cross-band/cross-VFO)
 const uint8_t BITMAP_XB[12] =

--- a/bitmaps.h
+++ b/bitmaps.h
@@ -21,6 +21,10 @@ extern const uint8_t BITMAP_F_Key[6];
 	extern const uint8_t BITMAP_VOX[18];
 #endif
 
+#ifdef ENABLE_CW_MODULATOR
+	extern const uint8_t BITMAP_BKIN[18];
+#endif
+
 extern const uint8_t BITMAP_XB[12];
 
 extern const uint8_t BITMAP_TDR1[16];

--- a/ui/main.c
+++ b/ui/main.c
@@ -700,7 +700,7 @@ void UI_DisplayMain(void)
 
 #ifdef ENABLE_CW_MODULATOR
 		if (vfoInfo->Modulation == MODULATION_CW && gCW_CrossMode)
-			UI_PrintStringSmallNormal("x", LCD_WIDTH + 40, 0, line + 1);
+			UI_PrintStringSmallNormal("x", LCD_WIDTH + 39, 0, line + 1);
 #endif
 
 		if (state == VFO_STATE_NORMAL || state == VFO_STATE_ALARM)

--- a/ui/status.c
+++ b/ui/status.c
@@ -28,6 +28,7 @@
 #include "functions.h"
 #include "helper/battery.h"
 #include "misc.h"
+#include "radio.h"
 #include "settings.h"
 #include "ui/battery.h"
 #include "ui/helper.h"
@@ -120,13 +121,25 @@ void UI_DisplayStatus()
 	}
 	x += sizeof(BITMAP_TDR1) + 1;
 
+#if defined(ENABLE_VOX) || defined(ENABLE_CW_MODULATOR)
+	{
+		bool _vox_bkin_shown = false;
+		(void)_vox_bkin_shown;
 #ifdef ENABLE_VOX
-	// VOX indicator
-	if (gEeprom.VOX_SWITCH) {
-		memcpy(line + x, BITMAP_VOX, sizeof(BITMAP_VOX));
-		x1 = x + sizeof(BITMAP_VOX) + 1;
+		if (gEeprom.VOX_SWITCH) {
+			memcpy(line + x, BITMAP_VOX, sizeof(BITMAP_VOX));
+			x1 = x + sizeof(BITMAP_VOX) + 1;
+			_vox_bkin_shown = true;
+		}
+#endif
+#ifdef ENABLE_CW_MODULATOR
+		if (!_vox_bkin_shown && gCurrentVfo->Modulation == MODULATION_CW && gEeprom.CW_BREAKIN_ENABLE) {
+			memcpy(line + x, BITMAP_BKIN, sizeof(BITMAP_BKIN));
+			x1 = x + sizeof(BITMAP_BKIN) + 1;
+		}
+#endif
+		x += 19; // 18-byte VOX/BKIN glyph + 1 gap (both bitmaps are the same width)
 	}
-	x += sizeof(BITMAP_VOX) + 1;
 #endif
 
 	x = MAX(x1, 61u);


### PR DESCRIPTION
- Status bar shows **BKIN** indicator when CW break-in is enabled
- Add several punctuation characters to the on-screen CW decoder and macro system (`.`, `,`, `=`, `-`)
- 3ms debounce added to CW key inputs to reduce spurious elements from contact noise and RFI
- Fixed a bug where ADC-read (CEC cable test) mode would trigger RF transmission (#23)
- Re-apply monitor-mode setting based on modulation when the VFO is reconfigured such going between VFO A/B or mem to VFO mode
- Add a short pre-delay when beginning to send while the squelch is closed (audio path off), preventing the leading edge of the first dit from being cut off
- Minor ADC read cleanup
- Keep backlight on during all sending (change via menu #39 BltTRX)