### PR TITLE
Issue 26 cw punctuation

### DIFF
--- a/app/cwmacro.c
+++ b/app/cwmacro.c
@@ -80,9 +80,9 @@ static const MorseCode_t MORSE_TABLE[] = {
 	// Punctuation
 	{'/', 5, 0b01001},    // -..-.
 	{'?', 6, 0b001100},    // ..--..
-	{'.', 6, 0b010101},    // .-.-.-
+	{'.', 6, 0b101010},    // .-.-.-
 	{',', 6, 0b110011},    // --..--
-	{'=', 6, 0b10001},      // -...-
+	{'=', 5, 0b10001},      // -...-
 	{'-', 6, 0b100001}     // -....-
 };
 
@@ -119,12 +119,14 @@ static const uint16_t MACRO_ADDRS[CW_MACRO_COUNT] = {
 
 bool CW_ValidateChar(char ch)
 {
-	// Valid characters: A-Z, 0-9, '/', '?'
+	// Valid characters: A-Z, 0-9, ',', '-', '.', '/', '?', '='
 	if (ch >= 'A' && ch <= 'Z')
 		return true;
-	if (ch >= '/' && ch <= '9')  // '/' to '9' are contiguous in ASCII
+	if (ch >= ',' && ch <= '9')  // ',' to '9' are contiguous in ASCII
 		return true;
 	if (ch == '?')
+		return true;
+	if (ch == '=')
 		return true;
 	return false;
 }
@@ -401,6 +403,7 @@ void CW_EncoderProcessElement(CW_ElementType_t element)
 #if CW_ENCODER_DEBUG
 			{
 				char buf[64];
+				// Note: here '?' is used for unknown, not for a question mark
 				sprintf_(buf, "  Result: ch='%c' (%d) valid=%d\r\n", 
 					ch ? ch : '?', ch, ch != 0 && CW_ValidateChar(ch));
 				UART_Send(buf, strlen(buf));

--- a/chirp/uvk5_NR7Y.py
+++ b/chirp/uvk5_NR7Y.py
@@ -852,7 +852,7 @@ class UVK5_NR7Y(uvk5_egzumer.UVK5RadioEgzumer):
                 # Validate character (A-Z, 0-9, /, ?)
                 if not ((char >= 'A' and char <= 'Z') or 
                         (char >= '0' and char <= '9') or 
-                        char in ['/', '?']):
+                        char in ['/', '?', ',', '.', '-', '=']):
                     LOG.warning(f"Skipping invalid char '{char}' in macro {idx}")
                     continue
                 


### PR DESCRIPTION
Fixes that work for me for issue #26 where the additional CW punctuation characters (added in release 1.0) were not being shown in the decoder or accepted into macros.

Tested on a v1 device for the encoder but I have not yet tested macros or download/upload via CHIRP.