### PR TITLE
Straight keys dont work on CEC cable

### DIFF
--- a/app/cwkeyer.c
+++ b/app/cwkeyer.c
@@ -548,7 +548,9 @@ CW_Action_t ptt_action(void)
 
     if(gEeprom.CW_KEY_INPUT & CW_KEY_FLAG_ADC) {
         // handkey CEC mode, either key works
-        CW_ReadADCkeys(&ptt, &ptt);
+        bool tip = false, ring = false;
+        CW_ReadADCkeys(&tip, &ring);
+        ptt = tip || ring;
     } else
     {    // Read PTT button (PC5) - active low
         ptt = !(GPIOC->DATA & (1U << GPIOC_PIN_PTT));


### PR DESCRIPTION

Howdy!

I found that a straight key doesn't work on a CEC cable if it is the tip that is switched. It'll be shadowed by ring always measuring 'false'.

Thank you for bring back live to my neglected Quansheng!

vy 73 de Seb, DM3SEB

